### PR TITLE
made Docker image smaller, set entrypoint and updated documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,14 @@ FROM perl:5.24
 
 ADD . /code
 
-RUN apt-get update -y
-RUN apt-get upgrade -y
-RUN apt-get install -y openssl libssl-dev
+RUN apt-get update &&\
+	apt-get install -y openssl libssl-dev &&\
+	rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
 
 RUN cpanm --quiet --installdeps --notest .
 RUN make && make install
 RUN ln -s /code/pwncheck /usr/bin/pwncheck
+
+ENTRYPOINT [ "/usr/bin/pwncheck" ]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Build the docker image:
 ```docker build -t pwncheck .```
 
 Run the image
-```docker run -it pwncheck ./pwncheck -h```
+```docker run -it --rm -e HIBP_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx pwncheck -h```
 
 ## Development
 


### PR DESCRIPTION
I made the Docker image build quite a bit smaller, and set the ENTRYPOINT so that way I can invoke `pwncheck` by just running the container rather than having to run the container and supplying the path to the executable. And just made updates to documentation that are relevant to the changes.

Hopefully the changes make sense! I am already using `pwncheck` and I love it.